### PR TITLE
Fix alt organization override (issue #2)

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -18,11 +18,6 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"github.com/containercraft/sparta-libs/config"
-	"github.com/mitchellh/go-homedir"
-	"gopkg.in/src-d/go-git.v4"
-	gitconfig "gopkg.in/src-d/go-git.v4/config"
-	"gopkg.in/src-d/go-git.v4/plumbing"
 	"log"
 	"os"
 	"os/exec"
@@ -30,10 +25,14 @@ import (
 	"strings"
 	"sync"
 
-	kpullsecret "github.com/containercraft/sparta-libs/pullsecret"
+	"github.com/containercraft/sparta-libs/config"
 	ksanity "github.com/containercraft/sparta-libs/err"
 	kcorelog "github.com/containercraft/sparta-libs/log"
+	kpullsecret "github.com/containercraft/sparta-libs/pullsecret"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	//  "github.com/containercraft/koffer/entrypoint/src"
 )
 
@@ -44,6 +43,10 @@ var (
 	dir           string
 	plugins       []string
 	defaultGitRef string
+)
+
+const (
+	defaultRunRegCmd string = "/usr/bin/run_registry.sh"
 )
 
 var bundleCmd = &cobra.Command{
@@ -166,7 +169,7 @@ func core() {
 		kofferLoop(pluginName)
 
 		// build url from vars
-		gitslice := []string{"https://", service, "/", user, "/", pluginName}
+		gitslice := []string{"https://", pluginObject.Service, "/", pluginObject.Organization, "/", pluginName}
 		url := strings.Join(gitslice, "")
 
 		runvars := "\n" +
@@ -323,7 +326,11 @@ func RemoveContents(dir string) error {
 
 func cmdRegistryStart() {
 	// Start Internal Registry Service
-	registry := exec.Command("/usr/bin/run_registry.sh")
+	runRegCmd, found := os.LookupEnv("RUN_REG_CMD")
+	if !found {
+		runRegCmd = defaultRunRegCmd
+	}
+	registry := exec.Command(runRegCmd)
 	err := registry.Start()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"gopkg.in/src-d/go-git.v4"
+	gitconfig "gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	//  "github.com/containercraft/koffer/entrypoint/src"
 )


### PR DESCRIPTION
This fixes https://github.com/ContainerCraft/koffer-go/issues/2 where a value provided in the koffer config file is not honored. 

I also added an additional env var (RUN_REG_CMD)  that can be used to override the default value for the command for running the container registry (so that this can be tested standalone). 

The default formatting also liked to reformat some of the imports, so there is that as well. 

Verifying the issue:
1. Build locally
2. Create a config file as described in the issue, e.g. in files/sparta.yml
```yaml
koffer:
  silent: false
  plugins:
    cloudctl:
      version: master
      service: github.com
      organization: containercraft
```
3. Export an env var to override the default value of the run_registry command
```bash
export RUN_REG_CMD=/usr/bin/true
```

4. Run koffer pointing to the config file
```bash
bin/koffer bundle --config=$(pwd)/files/sparta.yml
```

The output proceeds to displaying the URL and checks out the correct git URL:
```bash
$ bin/koffer bundle --config=$(pwd)/files/sparta.yml
Running Koffer Bundle....

  Please input your Quay.io Openshift Pull Secret.
  Find your secret at this url with valid access.redhat.com login:

    https://cloud.redhat.com/openshift/install/metal/user-provisioned

  Paste Secret:  123
Created: /home/akochnev/.docker/config.json
 >>  Running Plugin:  cloudctl

    Service: github.com
  User/Path: containercraft
     Plugin: cloudctl
        Ref: master
       Dest: /home/akochnev/koffer
        URL: https://github.com/containercraft/cloudctl
        CMD: git clone https://github.com/containercraft/cloudctl /home/akochnev/koffer

 >>  git clone https://github.com/containercraft/cloudctl /home/akochnev/koffer
```